### PR TITLE
3dpi  screen are miss edges with barline

### DIFF
--- a/components/slider-left/index.wxml
+++ b/components/slider-left/index.wxml
@@ -1,4 +1,4 @@
-<movable-area class="slider-left-item" style="width:{{openWidth * 2 + 750}}rpx;margin-left:-{{openWidth * 2}}rpx;">
+<movable-area class="slider-left-item" style="width:calc({{openWidth}}px + 750rpx);margin-left:-{{openWidth}}px;">
   <movable-view class="slider-left-content"
     damping="100"
     x="{{x}}"
@@ -9,6 +9,6 @@
     <slot></slot>
   </movable-view>
   <view class='slider-left-handle'>
-    <view bind:tap="handleDelete" class='handle-delete'>删除</view>
+    <view bind:tap="handleDelete" style="width:{{openWidth}}px" class='handle-delete'>删除</view>
   </view>
 </movable-area>


### PR DESCRIPTION
Hi, a little changed style for iPhone 6/7/8 plus and more devices with miss edges red right bars, caused by the movable-view is used px to calculated.

<img width="412" alt="screen shot 2018-07-16 at 1 31 35 pm" src="https://user-images.githubusercontent.com/3113374/42744173-0957bf6a-88fd-11e8-9e97-fd5d1b71182a.png">

for code slide review:

wechatide://minicode/OfM6zWme74fk

thank for this amazing jobs.

